### PR TITLE
docs: demonstrate with example using systemd to run donutdns

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,31 @@ Use the environment variables described above to configure things.
 $ DONUT_DNS_PORT=5533 DONUT_DNS_NO_DEBUG=1 donutdns
 ```
 
+#### as a systemd unit
+
+The [donutdns.service](donutdns.service) file provides an example Systemd Service Unit file for running
+donutdns via systemd.
+
+```
+# A minimal unit file, see donutdns.service for more.
+
+[Unit]
+Description=Block ads, trackers, and malicioius sites using DonutDNS.
+
+[Service]
+ExecStart=/opt/bin/donutdns
+Environment=DONUT_DNS_PORT=53
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Typically this file would be created at `/etc/systemd/system/donutdns.service`.
+
+Register the new unit with `sudo systemctl daemon-reload`
+Start the sevice with `sudo systemctl start donutdns`
+Check the service with `sudo systemctl status donutdns`
+
 #### as a docker container
 
 `donutdns` is available from [Docker Hub](https://hub.docker.com/repository/docker/shoenig/donutdns/general)

--- a/donutdns.service
+++ b/donutdns.service
@@ -1,0 +1,34 @@
+# This is an example systemd service file for running donutdns.
+#
+# It assumes the donutdns executable exists at /opt/bin/donutdns
+#
+# To use this service file:
+#   - Copy to /etc/systemd/system/donutdns.service
+#   - Run sudo systemctl daemon-reload
+#   - sudo systemctl start donutdns
+#
+# Check the status of the donutdns systemd service with
+#   - systemctl status donutdns
+#
+# If you have large block-lists you may need to tweak MemoryMax.
+# If donutdns is being used at scale you may want to set CPUWeight
+# to something higher than 100 (the default for systemd services).
+#
+# Environment variables can be configured as normal for systemd units.
+
+[Unit]
+Description=Block ads, trackers, and malicioius sites using DonutDNS.
+
+[Service]
+Type=simple
+ExecStart=/opt/bin/donutdns
+
+MemoryMax=42M
+CPUWeight=90
+
+Environment=DONUT_DNS_PORT=53
+Environment=DONUT_DNS_ALLOW=
+Environment=DONUT_DNS_BLOCK=
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This PR provides an example systemd unit file for donutdns, and some instructions on how to make use of it.